### PR TITLE
More consistent history function names

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -148,6 +148,13 @@ luaL_Reg linenoise_funcs[] = {
     { "clearscreen", l_clearscreen },
     { "setcompletion", l_setcompletion},
     { "addcompletion", l_addcompletion },
+
+    /* Aliases for more consistent function names */
+    { "addhistory", l_historyadd },
+    { "sethistorymaxlen", l_historysetmaxlen },
+    { "savehistory", l_historysave },
+    { "loadhistory", l_historyload },
+
     { NULL, NULL }
 };
 


### PR DESCRIPTION
History functions currently start with the noun and have the verb at the end, while completion functions start with the verb.
This patch makes it more consistent by adding aliases for the history functions which start with the verb.
